### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/ingestion/client/python/streaming_explicit_content_detection.py
+++ b/ingestion/client/python/streaming_explicit_content_detection.py
@@ -39,6 +39,7 @@ Sample Output:
     Time: 2.116857s
         pornography: VERY_UNLIKELY
 """
+from __future__ import print_function
 
 import argparse
 
@@ -82,14 +83,14 @@ def streaming_annotate(stream_file):
     responses = client.streaming_annotate_video(
         config_request, requests, timeout=10800)
 
-    print '\nReading response.'
+    print('\nReading response.')
     # Retrieve results from the response generator.
     for response in responses:
       for frame in response.annotation_results.explicit_annotation.frames:
         likelihood = enums.Likelihood(frame.pornography_likelihood)
         frame_time = frame.time_offset.seconds + frame.time_offset.nanos / 1e9
-        print 'Time: {}s'.format(frame_time)
-        print '\tpornography: {}'.format(likelihood.name)
+        print('Time: {}s'.format(frame_time))
+        print('\tpornography: {}'.format(likelihood.name))
 
 
 if __name__ == '__main__':

--- a/ingestion/client/python/streaming_label_detection.py
+++ b/ingestion/client/python/streaming_label_detection.py
@@ -38,6 +38,7 @@ Sample Output:
     ...
 
 """
+from __future__ import print_function
 
 import argparse
 
@@ -84,7 +85,7 @@ def streaming_annotate(stream_file):
     responses = client.streaming_annotate_video(
         config_request, requests, timeout=10800)
 
-    print '\nReading response.'
+    print('\nReading response.')
     # Retrieve results from the response generator.
     for response in responses:
       for annotation in response.annotation_results.label_annotations:
@@ -94,8 +95,8 @@ def streaming_annotate(stream_file):
         time_offset = annotation.frames[0].time_offset.seconds + \
                       annotation.frames[0].time_offset.nanos / 1e9
         confidence = annotation.frames[0].confidence
-        print '{}s: {}\t ({})'.format(
-            time_offset, description.encode('utf-8').strip(), confidence)
+        print('{}s: {}\t ({})'.format(
+            time_offset, description.encode('utf-8').strip(), confidence))
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(

--- a/ingestion/client/python/streaming_object_tracking.py
+++ b/ingestion/client/python/streaming_object_tracking.py
@@ -43,6 +43,7 @@ Sample Output:
             right : 0.218115285039
             bottom: 0.979368686676
 """
+from __future__ import print_function
 
 import argparse
 
@@ -86,7 +87,7 @@ def streaming_annotate(stream_file):
   responses = client.streaming_annotate_video(
       config_request, requests, timeout=10800)
 
-  print '\nReading response.'
+  print('\nReading response.')
   # Retrieve results from the response generator.
   for response in responses:
     object_annotations = response.annotation_results.object_annotations
@@ -98,12 +99,12 @@ def streaming_annotate(stream_file):
         confidence = annotation.confidence
         track_id = annotation.track_id
 
-        print 'Entity description: {}'.format(description)
-        print 'Track Id: {}'.format(track_id)
+        print('Entity description: {}'.format(description))
+        print('Track Id: {}'.format(track_id))
         if annotation.entity.entity_id:
-          print 'Entity id: {}'.format(annotation.entity.entity_id)
+          print('Entity id: {}'.format(annotation.entity.entity_id))
 
-        print 'Confidence: {}'.format(confidence)
+        print('Confidence: {}'.format(confidence))
 
         # In streaming mode, len(annotation.frames) is always 1, and the frames
         # in the same response share the same time_offset.
@@ -111,12 +112,12 @@ def streaming_annotate(stream_file):
         box = frame.normalized_bounding_box
         print('Time: {}s'.format(
             frame.time_offset.seconds + frame.time_offset.nanos / 1e9))
-        print 'Bounding box position:'
-        print '\tleft  : {}'.format(box.left)
-        print '\ttop   : {}'.format(box.top)
-        print '\tright : {}'.format(box.right)
-        print '\tbottom: {}'.format(box.bottom)
-        print '\n'
+        print('Bounding box position:')
+        print('\tleft  : {}'.format(box.left))
+        print('\ttop   : {}'.format(box.top))
+        print('\tright : {}'.format(box.right))
+        print('\tbottom: {}'.format(box.bottom))
+        print('\n')
 
 
 if __name__ == '__main__':

--- a/ingestion/client/python/streaming_shot_detection.py
+++ b/ingestion/client/python/streaming_shot_detection.py
@@ -41,6 +41,7 @@ Sample Output:
     Shot: 24.624624s to 30.063396s
 
 """
+from __future__ import print_function
 
 import argparse
 
@@ -84,15 +85,15 @@ def streaming_annotate(stream_file):
     responses = client.streaming_annotate_video(
         config_request, requests, timeout=10800)
 
-    print '\nReading response.'
+    print('\nReading response.')
     # Retrieve results from the response generator.
     for response in responses:
       for annotation in response.annotation_results.shot_annotations:
-        print 'Shot: {}s to {}s'.format(
+        print('Shot: {}s to {}s'.format(
             annotation.start_time_offset.seconds +
             annotation.start_time_offset.nanos / 1e9,
             annotation.end_time_offset.seconds +
-            annotation.end_time_offset.nanos / 1e9)
+            annotation.end_time_offset.nanos / 1e9))
 
 
 if __name__ == '__main__':

--- a/ingestion/client/python/streaming_storage.py
+++ b/ingestion/client/python/streaming_storage.py
@@ -37,6 +37,7 @@ Sample Output:
 After processing, annotation results will be available under the provided gcs
 bucket.
 """
+from __future__ import print_function
 
 import argparse
 
@@ -88,10 +89,10 @@ def streaming_annotate(stream_file, output_uri):
     responses = client.streaming_annotate_video(
         config_request, requests, timeout=10800)
 
-    print '\nReading response.'
+    print('\nReading response.')
     # Retrieve results from the response generator.
     for response in responses:
-      print 'Storage uri: {}'.format(response.annotation_results_uri)
+      print('Storage uri: {}'.format(response.annotation_results_uri))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.